### PR TITLE
Fix libs order

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,8 +5,8 @@ fn compile() -> String {
         "Debug"
     };
     let dst = cmake::Config::new("valhalla")
-        // .define("ENABLE_PYTHON_BINDINGS", "ON")
-        .cxxflag("-DGEOS_INLINE")
+         .define("ENABLE_PYTHON_BINDINGS", "OFF")
+        //.cxxflag("-DGEOS_INLINE")
         .define("CMAKE_BUILD_TYPE", build_type)
         .build();
 
@@ -37,6 +37,19 @@ fn generate_bindings(out_dir: String) {
 
     println!("cargo:rustc-link-search={}/lib", out_dir);
     println!("cargo:rustc-link-lib=valhalla");
+
+    println!("cargo:rustc-link-lib=prime_server");
+    println!("cargo:rustc-link-lib=protoc");
+    println!("cargo:rustc-link-lib=protobuf");
+    println!("cargo:rustc-link-lib=zmq");
+    println!("cargo:rustc-link-lib=z");
+    println!("cargo:rustc-link-lib=boost_program_options");
+    println!("cargo:rustc-link-lib=curl");
+    println!("cargo:rustc-link-lib=spatialite");
+    println!("cargo:rustc-link-lib=sqlite3");
+    println!("cargo:rustc-link-lib=luajit-5.1");
+    println!("cargo:rustc-link-lib=geos");
+    println!("cargo:rustc-link-lib=gssapi_krb5");
 }
 
 fn compile_protos() {
@@ -50,20 +63,6 @@ fn compile_protos() {
 }
 
 fn main() {
-    println!("cargo:rustc-link-lib=prime_server");
-    println!("cargo:rustc-link-lib=protoc");
-    println!("cargo:rustc-link-lib=protobuf");
-    println!("cargo:rustc-link-lib=zmq");
-    println!("cargo:rustc-link-lib=pthread");
-    println!("cargo:rustc-link-lib=z");
-    println!("cargo:rustc-link-lib=boost_program_options");
-    println!("cargo:rustc-link-lib=curl");
-    println!("cargo:rustc-link-lib=spatialite");
-    println!("cargo:rustc-link-lib=sqlite3");
-    println!("cargo:rustc-link-lib=luajit-5.1");
-    println!("cargo:rustc-link-lib=geos");
-    println!("cargo:rustc-link-lib=gssapi_krb5");
-
     let out_dir = compile();
     println!("OUT_DIR: {}", out_dir);
     generate_bindings(out_dir);

--- a/build.rs
+++ b/build.rs
@@ -1,28 +1,17 @@
-#[cfg(not(macos))]
 fn compile() -> String {
     let build_type = if Ok("release".to_owned()) == std::env::var("PROFILE") {
         "Release"
     } else {
         "Debug"
     };
-    let dst = cmake::Config::new("valhalla")
-         .define("ENABLE_PYTHON_BINDINGS", "OFF")
-        .define("CMAKE_BUILD_TYPE", build_type)
-        .build();
 
-    dst.display().to_string()
-}
+    let mut conf = cmake::Config::new("valhalla");
+    if cfg!(target_os = "macos") {
+        conf.cxxflag("-DGEOS_INLINE");
+    }
 
-#[cfg(macos)]
-fn compile() -> String {
-    let build_type = if Ok("release".to_owned()) == std::env::var("PROFILE") {
-        "Release"
-    } else {
-        "Debug"
-    };
-    let dst = cmake::Config::new("valhalla")
-         .define("ENABLE_PYTHON_BINDINGS", "OFF")
-        .cxxflag("-DGEOS_INLINE")
+    let dst = conf
+        .define("ENABLE_PYTHON_BINDINGS", "OFF")
         .define("CMAKE_BUILD_TYPE", build_type)
         .build();
 

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
+#[cfg(not(macos))]
 fn compile() -> String {
     let build_type = if Ok("release".to_owned()) == std::env::var("PROFILE") {
         "Release"
@@ -6,7 +7,22 @@ fn compile() -> String {
     };
     let dst = cmake::Config::new("valhalla")
          .define("ENABLE_PYTHON_BINDINGS", "OFF")
-        //.cxxflag("-DGEOS_INLINE")
+        .define("CMAKE_BUILD_TYPE", build_type)
+        .build();
+
+    dst.display().to_string()
+}
+
+#[cfg(macos)]
+fn compile() -> String {
+    let build_type = if Ok("release".to_owned()) == std::env::var("PROFILE") {
+        "Release"
+    } else {
+        "Debug"
+    };
+    let dst = cmake::Config::new("valhalla")
+         .define("ENABLE_PYTHON_BINDINGS", "OFF")
+        .cxxflag("-DGEOS_INLINE")
         .define("CMAKE_BUILD_TYPE", build_type)
         .build();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,10 @@ impl Actor {
 
 #[cfg(test)]
 mod tests {
-    use crate::route_inputs::{CostingModels, CostingOptions, Location, RoutingOptions};
-    use crate::Actor;
+    use crate::{
+        route_inputs::{CostingModels, CostingOptions, Location, RoutingOptions},
+        Actor,
+    };
 
     #[test]
     fn test_route() {


### PR DESCRIPTION
Somehow there was a linker problem on Linux. The libs were included via `-L`, but the linker could not find them. The solution is simple, just move all libraries to the end of the parameter's list.